### PR TITLE
Remove remote management capabilities

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"bytes"
-	"io"
-	"net/http"
 	"os"
 )
 
@@ -23,31 +21,6 @@ func NewConfig(path string, exampleDefault interface{}) (*Config, error) {
 		return nil, err
 	}
 	return &Config{path, exampleDefault}, nil
-}
-
-// HTTP returns handlers necessary to facilitate remotely reading and updating
-// the underlying configuration object
-func (c *Config) HTTP() http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case "GET":
-			cfgFile, err := os.Open(c.path)
-			if err != nil {
-				rw.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			defer cfgFile.Close()
-			io.Copy(rw, cfgFile)
-		case "POST":
-			cfgFile, err := os.OpenFile(c.path, os.O_WRONLY, 0666)
-			if err != nil {
-				rw.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			defer cfgFile.Close()
-			io.Copy(cfgFile, r.Body)
-		}
-	})
 }
 
 // Decode unmarshalls the underlying configuration file into the target object.

--- a/config_test.go
+++ b/config_test.go
@@ -3,8 +3,6 @@ package config
 import (
 	"bytes"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -13,72 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_RemoteRead(t *testing.T) {
-	cfgFile, err := ioutil.TempFile("", "config")
-	r := require.New(t)
-	defer func() {
-		err := cfgFile.Close()
-		r.NoError(err)
-		os.Remove(cfgFile.Name())
-	}()
-
-	expect := `
-[test]
-hostname="localhost"
-port=8080
-`
-	cfgFile.WriteString(expect)
-
-	cfg, err := NewConfig(cfgFile.Name(), nil)
-	r.NoError(err)
-	defer os.Remove(cfgFile.Name())
-
-	ts := httptest.NewServer(cfg.HTTP())
-	defer ts.Close()
-
-	res, err := http.Get(ts.URL)
-	r.NoError(err)
-
-	actual, err := ioutil.ReadAll(res.Body)
-	r.NoError(err)
-
-	r.Equal(expect, string(actual))
-}
-
 func Test_NonexistantFile(t *testing.T) {
 	r := require.New(t)
 	_, err := NewConfig("/tmp/does/not/exist.conf", nil)
 	r.Error(err)
-}
-
-func Test_RemoteUpdate(t *testing.T) {
-	r := require.New(t)
-	cfgFile, err := ioutil.TempFile("", "config")
-	r.NoError(err)
-	defer os.Remove(cfgFile.Name())
-
-	cfg, err := NewConfig(cfgFile.Name(), nil)
-	r.NoError(err)
-
-	expect := `
-[test]
-hostname="localhost"
-port=8080
-`
-
-	ts := httptest.NewServer(cfg.HTTP())
-	defer ts.Close()
-
-	resp, err := http.Post(ts.URL, "text/plain", strings.NewReader(expect))
-	r.NoError(err)
-	defer resp.Body.Close()
-
-	r.Equal(200, resp.StatusCode)
-
-	actual, err := ioutil.ReadAll(cfgFile)
-	r.NoError(err)
-
-	r.Equal(expect, string(actual))
 }
 
 type testConfig struct {


### PR DESCRIPTION
This removes the HTTP handlers that were previously present to provide
remote configuration management capabilities. These were half-baked at
best, and it probably better handled by an external tool rather than the
library that an application depends on to read its configuration.
